### PR TITLE
Serialisation and deserialisation of cookies: failing tests, plus fixes to pass tests

### DIFF
--- a/redisstorage.go
+++ b/redisstorage.go
@@ -48,16 +48,12 @@ func (s *Storage) Init() error {
 func (s *Storage) Destroy() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	prefix := "*"
-	if s.Prefix != "" {
-		prefix = s.Prefix
-	}
-	r := s.Client.Keys(prefix + ":cookie:*")
+	r := s.Client.Keys(s.Prefix + ":cookie:*")
 	keys, err := r.Result()
 	if err != nil {
 		return err
 	}
-	r2 := s.Client.Keys(prefix + ":request:*")
+	r2 := s.Client.Keys(s.Prefix + ":request:*")
 	keys2, err := r2.Result()
 	if err != nil {
 		return err

--- a/redisstorage.go
+++ b/redisstorage.go
@@ -2,9 +2,11 @@ package redisstorage
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -23,6 +25,8 @@ type Storage struct {
 	Prefix string
 	// Client is the redis connection
 	Client *redis.Client
+
+	mu sync.RWMutex // Only used for cookie methods.
 }
 
 // Init initializes the redis storage
@@ -39,6 +43,27 @@ func (s *Storage) Init() error {
 		return fmt.Errorf("Redis connection error: %s", err.Error())
 	}
 	return err
+}
+
+func (s *Storage) Destroy() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prefix := "*"
+	if s.Prefix != "" {
+		prefix = s.Prefix
+	}
+	r := s.Client.Keys(prefix + ":cookie:*")
+	keys, err := r.Result()
+	if err != nil {
+		return err
+	}
+	r2 := s.Client.Keys(prefix + ":request:*")
+	keys2, err := r2.Result()
+	if err != nil {
+		return err
+	}
+	keys = append(keys, keys2...)
+	return s.Client.Del(keys...).Err()
 }
 
 // Visited implements colly/storage.Visited()
@@ -65,47 +90,78 @@ func (s *Storage) GetCookieJar() http.CookieJar {
 // SetCookies implements http/CookieJar.SetCookies()
 func (s *Storage) SetCookies(u *url.URL, cookies []*http.Cookie) {
 	// TODO RFC 6265
-	cookieStrings := make([]string, 0, len(cookies))
-	for _, c := range cookies {
-		cookieStrings = append(cookieStrings, c.String())
+
+	// TODO(js) Cookie methods currently have no way to return an error.
+
+	// We need to use a write lock to prevent a race in the db:
+	// if two callers set cookies in a very small window of time,
+	// it is possible to drop the new cookies from one caller
+	// ('last update wins' == best avoided).
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cookieStr, err := s.Client.Get(s.getCookieID(u.Host)).Result()
+	if err == redis.Nil {
+		cookieStr = ""
+	} else if err != nil {
+		// return nil
+		log.Printf("SetCookies() .Get error %s", err)
+		return
 	}
-	for _, c := range s.Cookies(u) {
-		duplication := false
-		for _, c2 := range cookies {
-			if c2.Name == c.Name {
-				duplication = true
-				break
-			}
-		}
-		if !duplication {
-			cookieStrings = append(cookieStrings, c.String())
+
+	// Merge existing cookies, new cookies have precendence.
+	cnew := make([]*http.Cookie, len(cookies))
+	copy(cnew, cookies)
+	existing := unstringify(cookieStr)
+	for _, c := range existing {
+		if !contains(cnew, c.Name) {
+			cnew = append(cnew, c)
 		}
 	}
-	s.Client.Set(s.getCookieID(u.Host), strings.Join(cookieStrings, "\n"), 0).Err()
+	// return s.Client.Set(s.getCookieID(u.Host), stringify(cnew), 0).Err()
+	err = s.Client.Set(s.getCookieID(u.Host), stringify(cnew), 0).Err()
+	if err != nil {
+		// return nil
+		log.Printf("SetCookies() .Set error %s", err)
+		return
+	}
 }
 
 // Cookies implements http/CookieJar.Cookies()
 func (s *Storage) Cookies(u *url.URL) []*http.Cookie {
 	// TODO RFC 6265
-	cookieStr, err := s.Client.Get(s.getCookieID(u.Host)).Result()
-	if err != nil {
+	// TODO(js) Cookie methods currently have no way to return an error.
+
+	s.mu.RLock()
+	cookiesStr, err := s.Client.Get(s.getCookieID(u.Host)).Result()
+	s.mu.RUnlock()
+	if err == redis.Nil {
+		cookiesStr = ""
+	} else if err != nil {
+		// return nil, err
+		log.Printf("Cookies() .Get error %s", err)
 		return nil
 	}
-	header := http.Header{}
-	for _, cs := range strings.Split(cookieStr, "\n") {
-		header.Add("Cookie", cs)
-	}
-	request := http.Request{Header: header}
-	rc := request.Cookies()
-	cookies := make([]*http.Cookie, 0, len(rc))
+
+	// Parse raw cookies string to []*http.Cookie.
+	cookies := unstringify(cookiesStr)
+
+	// Filter.
 	now := time.Now()
-	for _, c := range rc {
-		if c.RawExpires != "" && !c.Expires.After(now) {
+	cnew := make([]*http.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		// Drop expired cookies.
+		if c.RawExpires != "" && c.Expires.Before(now) {
 			continue
 		}
-		cookies = append(cookies, c)
+		// Drop secure cookies if not over https.
+		if c.Secure && u.Scheme != "https" {
+			continue
+		}
+		cnew = append(cnew, c)
 	}
-	return cookies
+	// return cnew, nil
+	return cnew
 }
 
 func (s *Storage) getIDStr(ID uint64) string {
@@ -114,4 +170,31 @@ func (s *Storage) getIDStr(ID uint64) string {
 
 func (s *Storage) getCookieID(c string) string {
 	return fmt.Sprintf("%s:cookie:%s", s.Prefix, c)
+}
+
+func stringify(cookies []*http.Cookie) string {
+	// Stringify cookies.
+	cs := make([]string, len(cookies))
+	for i, c := range cookies {
+		cs[i] = c.String()
+	}
+	return strings.Join(cs, "\n")
+}
+
+func unstringify(s string) []*http.Cookie {
+	h := http.Header{}
+	for _, c := range strings.Split(s, "\n") {
+		h.Add("Set-Cookie", c)
+	}
+	r := http.Response{Header: h}
+	return r.Cookies()
+}
+
+func contains(cookies []*http.Cookie, name string) bool {
+	for _, c := range cookies {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/redisstorage_cookies_test.go
+++ b/redisstorage_cookies_test.go
@@ -62,7 +62,51 @@ var _ = Describe("Storage CookieJar", func() {
 		Expect(sgot).To(ContainElement(cookies[1].String()))
 	})
 
-	It("should add cookies to existing cookies", func() {
+	It("should update existing cookies", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// SetCookies.
+		url, _ := url.Parse("http://example.org")
+		cookies := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+			&http.Cookie{
+				Name:   "cookie2_name",
+				Value:  "cookie2_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, cookies)).To(BeNil())
+		s.SetCookies(url, cookies)
+
+		// Change existing.
+		update := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_value_new",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, update)).To(BeNil())
+		s.SetCookies(url, update)
+		// Get existing.
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(2))
+		sgot := toStrings(got)
+		Expect(sgot).To(ContainElement(update[0].String()))
+	})
+
+	It("should add new cookies to existing cookies", func() {
 		s := newStore()
 		Expect(s.Init()).To(BeNil())
 		defer s.Destroy()

--- a/redisstorage_cookies_test.go
+++ b/redisstorage_cookies_test.go
@@ -1,0 +1,254 @@
+package redisstorage_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/jimsmart/redisstorage"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Storage CookieJar", func() {
+
+	newStore := func() *redisstorage.Storage {
+		// TODO(js) For ease of testing, these settings should probably come from environment variables.
+		s := &redisstorage.Storage{
+			Address:  "127.0.0.1:32768",
+			Password: "",
+			DB:       0,
+			Prefix:   randomName(),
+		}
+		return s
+	}
+
+	It("should set and get cookies", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// SetCookies.
+		url, _ := url.Parse("http://example.org")
+		cookies := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+			&http.Cookie{
+				Name:   "cookie2_name",
+				Value:  "cookie2_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, cookies)).To(BeNil())
+		s.SetCookies(url, cookies)
+		// Get existing.
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+
+		Expect(got).To(HaveLen(2))
+		sgot := toStrings(got)
+		Expect(sgot).To(ContainElement("cookie1_name=cookie1_value; Path=/; Domain=example.org"))
+		Expect(sgot).To(ContainElement(cookies[0].String()))
+		Expect(sgot).To(ContainElement(cookies[1].String()))
+	})
+
+	It("should add cookies to existing cookies", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// SetCookies.
+		url, _ := url.Parse("http://example.org")
+		cookies := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+			&http.Cookie{
+				Name:   "cookie2_name",
+				Value:  "cookie2_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, cookies)).To(BeNil())
+		s.SetCookies(url, cookies)
+
+		// Add another.
+		more := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie3_name",
+				Value:  "cookie3_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, more)).To(BeNil())
+		s.SetCookies(url, more)
+		// Get existing.
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(3))
+		sgot := toStrings(got)
+		Expect(sgot).To(ContainElement(more[0].String()))
+	})
+
+	It("should drop expired cookies", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// SetCookies.
+		url, _ := url.Parse("http://example.org")
+		cookies := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+			&http.Cookie{
+				Name:   "cookie2_name",
+				Value:  "cookie2_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, cookies)).To(BeNil())
+		s.SetCookies(url, cookies)
+		// Get existing.
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(2))
+
+		// Expire a cookie.
+		expired := []*http.Cookie{
+			&http.Cookie{
+				Name:    "cookie1_name",
+				Path:    "/",
+				Domain:  ".example.org",
+				Expires: time.Now(),
+			},
+		}
+		// Expect(s.SetCookies(url, expired)).To(BeNil())
+		s.SetCookies(url, expired)
+		// got, err = s.Cookies(url)
+		got = s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(1))
+		Expect(got[0].String()).To(Equal("cookie2_name=cookie2_value; Path=/; Domain=example.org"))
+	})
+
+	It("should drop secure cookies if not over https", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// SetCookies - one is marked secure.
+		url, _ := url.Parse("https://example.org")
+		cookies := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_value",
+				Path:   "/",
+				Domain: ".example.org",
+				Secure: true,
+			},
+			&http.Cookie{
+				Name:   "cookie2_name",
+				Value:  "cookie2_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, cookies)).To(BeNil())
+		s.SetCookies(url, cookies)
+		// Get existing.
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(2))
+		// Get for http.
+		url, _ = url.Parse("http://example.org")
+		// got, err = s.Cookies(url)
+		got = s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(1))
+		Expect(got[0].String()).To(Equal("cookie2_name=cookie2_value; Path=/; Domain=example.org"))
+	})
+
+	It("should not get cookies for an unknown domain", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// Get non-existing.
+		url, _ := url.Parse("http://no-such-domain.org")
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(0))
+	})
+
+	It("should handle cookies containing a newline", func() {
+		s := newStore()
+		Expect(s.Init()).To(BeNil())
+		defer s.Destroy()
+
+		// SetCookies.
+		url, _ := url.Parse("http://example.org")
+		cookies := []*http.Cookie{
+			&http.Cookie{
+				Name:   "cookie1_name",
+				Value:  "cookie1_\n_value",
+				Path:   "/",
+				Domain: ".example.org",
+			},
+		}
+		// Expect(s.SetCookies(url, cookies)).To(BeNil())
+		s.SetCookies(url, cookies)
+		// Get existing.
+		// got, err := s.Cookies(url)
+		got := s.Cookies(url)
+		// Expect(err).To(BeNil())
+		Expect(got).To(HaveLen(1))
+		// It turns out that this is ok, net/http handles this,
+		// and emits a warning  ('dropping invalid bytes') to the console when it does so.
+		Expect(got[0].String()).To(Equal("cookie1_name=cookie1__value; Path=/; Domain=example.org"))
+		Expect(got[0].String()).To(Equal(cookies[0].String()))
+	})
+
+})
+
+func toStrings(cookies []*http.Cookie) []string {
+	s := make([]string, len(cookies))
+	for i, c := range cookies {
+		s[i] = c.String()
+	}
+	return s
+}
+
+func randomName() string {
+	b := make([]byte, 8)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h := make([]byte, hex.EncodedLen(len(b)))
+	hex.Encode(h, b)
+	return string(h)
+}

--- a/redisstorage_suite_test.go
+++ b/redisstorage_suite_test.go
@@ -1,0 +1,13 @@
+package redisstorage_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRedisStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RedisStorage Suite")
+}


### PR DESCRIPTION
Hi,

This pull request adds tests to troubleshoot issues with both `Cookies()` and `SetCookies()`, plus the appropriate fixes for those methods to pass all the tests.

I've also added `Destroy()` to `Storage`, primarily to make all this testable, but it's probably needed anyway.

Tests have a dependency on Ginkgo and Gomega:
```bash
$ go get github.com/onsi/ginkgo/ginkgo
$ go get github.com/onsi/gomega/...
```

You will need to edit `newStore()` in `redisstorage_cookies_test.go` to point to your Redis before running the tests.

Perhaps a separate issue needs filing: you recently removed `Close()`, but you are in fact using a strategy that is based on long connections, and now your connection never gets closed. (When I said I didn't personally need it, it's because I follow a different strategy, specifically to avoid long connections, that is: in each of my methods I always obtain a new connection and close it again before returning.) — this pull request does not address this issue.

 — But let's continue the more general conversation about features / refactoring, over on https://github.com/gocolly/colly/issues/103