### PR TITLE
Make Visited storage expirable

### DIFF
--- a/redisstorage.go
+++ b/redisstorage.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/go-redis/redis"
 )
@@ -22,6 +23,10 @@ type Storage struct {
 	Prefix string
 	// Client is the redis connection
 	Client *redis.Client
+
+	// Expiration time for Visited keys. After expiration pages
+	// are to be visited again.
+	Expires time.Duration
 
 	mu sync.RWMutex // Only used for cookie methods.
 }
@@ -63,7 +68,7 @@ func (s *Storage) Clear() error {
 
 // Visited implements colly/storage.Visited()
 func (s *Storage) Visited(requestID uint64) error {
-	return s.Client.Set(s.getIDStr(requestID), "1", 0).Err()
+	return s.Client.Set(s.getIDStr(requestID), "1", s.Expires).Err()
 }
 
 // IsVisited implements colly/storage.IsVisited()


### PR DESCRIPTION
Add option to configure expiration time for visited keys. Go defaults time.Duration to zero so this should not be breaking change.

This is an easy way for refetching some pages after given interval as well as to clean up old entires from Redis without removing everything.